### PR TITLE
Explicitly require 'fileutils'

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    nokogiri (1.16.0-aarch64-linux)
+    mini_portile2 (2.8.7)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.16.0-arm-linux)
-      racc (~> 1.4)
-    nokogiri (1.16.0-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.16.0-x86-linux)
-      racc (~> 1.4)
-    nokogiri (1.16.0-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.16.0-x86_64-linux)
-      racc (~> 1.4)
-    racc (1.7.3)
+    racc (1.8.1)
 
 PLATFORMS
   aarch64-linux

--- a/lib/html_generator.rb
+++ b/lib/html_generator.rb
@@ -1,5 +1,6 @@
 require 'erb'
 require 'uri'
+require 'fileutils'
 
 class HtmlGenerator
   def initialize(speakers, years)


### PR DESCRIPTION
Currently `FileUtils` is used inside html_generator.rb and it expects 'fileutils' to be already loaded. This may be true in some cases, but that's not always the case.

My experience was that I tried to run this program on Ruby 3.4 (as of yesterday) on my MBP, and when I hit `bundle install` it updates nokogiri to 1.16.7 (from 1.16.0) for some reason, then when I ran main.rb, I saw `uninitialized constant HtmlGenerator::FileUtils (NameError)`.

I haven't investigated the root cause deeper, but I know that RubyGems requires 'fileutils' here and there in adhoc-style, and perhaps there may have been some sort of change that skips loading 'fileutils' in between 3.5.18 and 3.6.0.dev (bundled in ruby trunk).

Anyway, it may be safer to always explicitly require when this kind of non-core stdlib. Also, appended a `bundle update` commit so we can run the scripts on trunk without `bundle update`ing.