### PR TITLE
Use YAMLs

### DIFF
--- a/2022/index.html
+++ b/2022/index.html
@@ -90,6 +90,12 @@
               
               <tr>
                 <td><a href='/2022'>2022</a></td>
+                <td><a href='/speakers/mame+%26+the+judges'>mame & the judges</a></td>
+                <td><a href='https://rubykaigi.org/2022/presentations/tric.html#day1' target='_blank'>TRICK 2022 (Returns)</a></td>
+              </tr>
+              
+              <tr>
+                <td><a href='/2022'>2022</a></td>
                 <td><a href='/speakers/Takashi+Kokubun'>Takashi Kokubun</a></td>
                 <td><a href='https://rubykaigi.org/2022/presentations/k0kubun.html#day1' target='_blank'>Towards Ruby 4 JIT</a></td>
               </tr>
@@ -140,6 +146,12 @@
                 <td><a href='/2022'>2022</a></td>
                 <td><a href='/speakers/Koichi+ITO'>Koichi ITO</a></td>
                 <td><a href='https://rubykaigi.org/2022/presentations/koic.html#day2' target='_blank'>Make RuboCop super fast</a></td>
+              </tr>
+              
+              <tr>
+                <td><a href='/2022'>2022</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2022/presentations/rubylangorg.html#day2' target='_blank'>Ruby Committers vs The World</a></td>
               </tr>
               
               <tr>

--- a/downloader.rb
+++ b/downloader.rb
@@ -2,16 +2,20 @@ require 'open-uri'
 require 'fileutils'
 
 class Downloader
+  def self.yamls_for(year)
+    ["https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/#{year}/data/speakers.yml", "https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/#{year}/data/presentations.yml", "https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/#{year}/data/schedule.yml"]
+  end
+
   YEARS = {
-    '2024' => ['https://rubykaigi.org/2024/schedule/index.html'],
-    '2023' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2023/schedule/index.html'],
-    '2022' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2022/schedule/index.html'],
-    '2021-takeout' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2021-takeout/schedule/index.html'],
+    '2024' => ['https://rubykaigi.org/2024/data/speakers.yml', 'https://rubykaigi.org/2024/data/presentations.yml', 'https://rubykaigi.org/2024/data/schedule.yml'],
+    '2023' => yamls_for(2023),
+    '2022' => yamls_for(2022),
+    '2021-takeout' => yamls_for('2021-takeout'),
     '2020-takeout' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2020-takeout/schedule/index.html'],
     '2019' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2019/schedule/index.html'],
     '2018' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2018/schedule/index.html'],
     '2017' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2017/schedule/index.html'],
-    '2016' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2016/schedule/index.html'],
+    '2016' => yamls_for(2016),
     '2015' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2015/schedule/index.html'],
     '2014' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2014/schedule/index.html'],
     '2013' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2013/schedule/index.html'],
@@ -42,8 +46,12 @@ class Downloader
   end
 
   def self.extract_filename(uri)
-    filename = uri.match(/(\d{4}-takeout|\d{4})\/(.*html)/)[2]
-    filename.gsub('/', '_')
+    if uri.end_with?('.yml')
+      File.basename(uri)
+    else
+      filename = uri.match(/(\d{4}-takeout|\d{4})\/(.*html)/)[2]
+      filename.gsub('/', '_')
+    end
   end
 end
 

--- a/index.html
+++ b/index.html
@@ -2957,6 +2957,12 @@
               </tr>
               
               <tr>
+                <td><a href='/2022'>2022</a></td>
+                <td><a href='/speakers/mame+%26+the+judges'>mame & the judges</a></td>
+                <td><a href='https://rubykaigi.org/2022/presentations/tric.html#day1' target='_blank'>TRICK 2022 (Returns)</a></td>
+              </tr>
+              
+              <tr>
                 <td><a href='/2013'>2013</a></td>
                 <td><a href='/speakers/zzak'>zzak</a></td>
                 <td><a href='https://rubykaigi.org/2013/talk/S09' target='_blank'>Contributing to Ruby</a></td>
@@ -4304,6 +4310,12 @@
                 <td><a href='/2021-takeout'>2021-takeout</a></td>
                 <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
                 <td><a href='https://rubykaigi.org/2021-takeout/presentations/rubylangorg.html' target='_blank'>Ruby Committers vs the World</a></td>
+              </tr>
+              
+              <tr>
+                <td><a href='/2022'>2022</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2022/presentations/rubylangorg.html#day2' target='_blank'>Ruby Committers vs The World</a></td>
               </tr>
               
               <tr>

--- a/lib/speaker.rb
+++ b/lib/speaker.rb
@@ -1,4 +1,5 @@
 require 'nokogiri'
+require 'yaml'
 require_relative 'speaker_normalizer'
 
 class Speaker
@@ -360,39 +361,68 @@ class Speaker
     talks
   end
 
+  def get_speakers_from_yaml(year)
+    speakers_yml = YAML.load_file(File.expand_path("schedule/#{year}/speakers.yml"))
+    speaker_id_to_name = speakers_yml.values.inject(:merge)
+    speaker_id_to_name.each {|k, v| speaker_id_to_name[k] = v['name'] }
+
+    presentations_yml = YAML.load_file(File.expand_path("schedule/#{year}/presentations.yml"))
+    talk_id_to_title = presentations_yml.map { [it[0], it[1]['title']] }.to_h
+    speaker_id_to_speaker_ids = presentations_yml.map {|y| [y[0], y[1]['speakers'].map { it.values.last }] }.to_h
+
+    Hash.new { |h, k| h[k] = {} }.tap do |talks|
+      schedule_yml = YAML.load_file(File.expand_path("schedule/#{year}/schedule.yml"))
+      schedule_yml.each_value.with_index(1) do |schedule_per_day, day|
+        schedule_per_day['events'].filter_map { it['talks']&.values }.flatten.each do |talk_id|
+          url = "/#{year}/presentations/#{talk_id}.html#{"#day#{day}" if year.to_i >= 2022}"
+          speaker_id_to_speaker_ids[talk_id].each do |speaker_id|
+            name = SpeakerNormalizer.unify(speaker_id_to_name[speaker_id])
+            title = talk_id_to_title[talk_id]
+            add_speakers(talks, year, name, speaker_id, title, url)
+          end
+        end
+      end
+    end
+  end
+
   def get_all_speakers
     @years.each do |year|
       files = Dir.glob("schedule/#{year}/*")
       talks = {}
 
-      talks = case year
-              when '2024', '2023', '2022'
-                get_speakers_since_2022(year, files)
-              when '2021-takeout'
-                get_speakers_in_2021_takeout(year, files)
-              when '2020-takeout', '2019', '2018', '2017'
-                get_speakers_2017_to_2020(year, files)
-              when '2016', '2015'
-                get_speakers_2015_to_2016(year, files)
-              when '2014'
-                get_speakers_in_2014(year, files)
-              when '2013'
-                get_speakers_in_2013(year, files)
-              when '2011'
-                get_speakers_in_2011(year, files)
-              when '2010'
-                get_speakers_in_2010(year, files)
-              when '2009'
-                get_speakers_in_2009(year, files)
-              when '2008'
-                get_speakers_in_2008(year, files)
-              when '2007'
-                get_speakers_in_2007(year, files)
-              when '2006'
-                get_speakers_in_2006(year, files)
-              else
-                {}
-              end
+      talks =
+        if File.exist?(File.expand_path("schedule/#{year}/speakers.yml"))
+          get_speakers_from_yaml(year)
+        else
+          case year
+          when '2024', '2023', '2022'
+            get_speakers_since_2022(year, files)
+          when '2021-takeout'
+            get_speakers_in_2021_takeout(year, files)
+          when '2020-takeout', '2019', '2018', '2017'
+            get_speakers_2017_to_2020(year, files)
+          when '2016', '2015'
+            get_speakers_2015_to_2016(year, files)
+          when '2014'
+            get_speakers_in_2014(year, files)
+          when '2013'
+            get_speakers_in_2013(year, files)
+          when '2011'
+            get_speakers_in_2011(year, files)
+          when '2010'
+            get_speakers_in_2010(year, files)
+          when '2009'
+            get_speakers_in_2009(year, files)
+          when '2008'
+            get_speakers_in_2008(year, files)
+          when '2007'
+            get_speakers_in_2007(year, files)
+          when '2006'
+            get_speakers_in_2006(year, files)
+          else
+            {}
+          end
+        end
 
       @speakers = @speakers.merge(talks) { |_, old, new| old.merge(new) }
     end

--- a/lib/speaker.rb
+++ b/lib/speaker.rb
@@ -376,9 +376,11 @@ class Speaker
         schedule_per_day['events'].filter_map { it['talks']&.values }.flatten.each do |talk_id|
           url = "/#{year}/presentations/#{talk_id}.html#{"#day#{day}" if year.to_i >= 2022}"
           speaker_id_to_speaker_ids[talk_id].each do |speaker_id|
-            name = SpeakerNormalizer.unify(speaker_id_to_name[speaker_id])
-            title = talk_id_to_title[talk_id]
-            add_speakers(talks, year, name, speaker_id, title, url)
+            if (name = speaker_id_to_name[speaker_id])
+              name = SpeakerNormalizer.unify(name)
+              title = talk_id_to_title[talk_id]
+              add_speakers(talks, year, name, speaker_id, title, url)
+            end
           end
         end
       end

--- a/speakers/CRuby+Committers/index.html
+++ b/speakers/CRuby+Committers/index.html
@@ -35,6 +35,12 @@
               </tr>
               
               <tr>
+                <td><a href='/2022'>2022</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2022/presentations/rubylangorg.html#day2' target='_blank'>Ruby Committers vs The World</a></td>
+              </tr>
+              
+              <tr>
                 <td><a href='/2023'>2023</a></td>
                 <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
                 <td><a href='https://rubykaigi.org/2023/presentations/rubylangorg.html#day3' target='_blank'>Ruby Committers and The World</a></td>

--- a/speakers/mame+%26+the+judges/index.html
+++ b/speakers/mame+%26+the+judges/index.html
@@ -40,6 +40,12 @@
                 <td><a href='https://rubykaigi.org/2018/presentations/tric.html#jun02' target='_blank'>TRICK 2018 (FINAL)</a></td>
               </tr>
               
+              <tr>
+                <td><a href='/2022'>2022</a></td>
+                <td><a href='/speakers/mame+%26+the+judges'>mame & the judges</a></td>
+                <td><a href='https://rubykaigi.org/2022/presentations/tric.html#day1' target='_blank'>TRICK 2022 (Returns)</a></td>
+              </tr>
+              
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
HTMLファイルをスクレイピングする代わりにYAMLファイルがある場合はそっちから情報を引っ張ってくるやつをやってみました。

さまざまな歴史的事情により、今のところ外部APIとしてのYAMLファイルが公開されてるのは 2016, 2021-takeout, 2022, 2023, および 2024だけなので、そこだけYAMLを使うように書き換えています。

ちなみに、HTMLのほうとのデータの整合性については、そもそものrubykaigi.orgのHTML生成の流れが、
1. cfp-app上で更新を検知すると各種YAMLファイルを生成してrubykaigi.orgのリポジトリにぷるりを送る
2. ぷるりをマージするタイミングで勝手にstatic site generatorが走って、最新のYAMLのデータを反映した成果物をrubykaigi.orgにデプロイする

という手順になっているので、つまりYAMLが一次データでHTMLはそれを元に随時生成されるようになっているので、同期は100%取られていると思っていただいて大丈夫です。

そんな感じで処理を更新してスクリプトを流してみると、2022年に微妙にコマが増える結果となりました(vs the World と TRICK)。これは実際にサイトを見てみるとわかるんですが、YAMLに情報は載ってて、トークの個別ページにはスピーカー名として載ってて、でもタイムテーブル上ではなんかスピーカー名は省略されてる、みたいなビミョウな例でした。これは、単にHTMLマークアップ時に落ちた情報っぽいので、今回からこちらのサイトには追加されることになります。

それ以外は何も差分が出なかったので、かなりコンパチビリティは保ててるんじゃないかと思います。あ、あと、コンパチビリティといえば、`_1`とか書きたくなくて日常的に`it`を使ってるので、これを取り込むとRuby 3.4以上でしか動作しなくなります。ご承知おきください。

closes #1
