### PR TITLE
Moar YAMLs

### DIFF
--- a/2017/index.html
+++ b/2017/index.html
@@ -282,6 +282,12 @@
               
               <tr>
                 <td><a href='/2017'>2017</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2017/presentations/rubylangorg.html' target='_blank'>Ruby Committers vs the World</a></td>
+              </tr>
+              
+              <tr>
+                <td><a href='/2017'>2017</a></td>
                 <td><a href='/speakers/Chris+Salzberg'>Chris Salzberg</a></td>
                 <td><a href='https://rubykaigi.org/2017/presentations/shioyama.html' target='_blank'>The Ruby Module Builder Pattern</a></td>
               </tr>

--- a/2018/index.html
+++ b/2018/index.html
@@ -222,6 +222,12 @@
               
               <tr>
                 <td><a href='/2018'>2018</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2018/presentations/rubylangorg.html#jun01' target='_blank'>Ruby Committers vs the World</a></td>
+              </tr>
+              
+              <tr>
+                <td><a href='/2018'>2018</a></td>
                 <td><a href='/speakers/ITOYANAGI+Sakura'>ITOYANAGI Sakura</a></td>
                 <td><a href='https://rubykaigi.org/2018/presentations/aycabta.html#jun02' target='_blank'>IRB Reboot: Modernize Implementation and Features</a></td>
               </tr>
@@ -344,12 +350,6 @@
                 <td><a href='/2018'>2018</a></td>
                 <td><a href='/speakers/Vladimir+Dementyev'>Vladimir Dementyev</a></td>
                 <td><a href='https://rubykaigi.org/2018/presentations/palkan_tula.html#jun01' target='_blank'>One cable to rule them all</a></td>
-              </tr>
-              
-              <tr>
-                <td><a href='/2018'>2018</a></td>
-                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
-                <td><a href='https://rubykaigi.org/2018/presentations/rubylangorg.html#jun01' target='_blank'>Ruby Committers vs the World</a></td>
               </tr>
               
               <tr>

--- a/2019/index.html
+++ b/2019/index.html
@@ -49,7 +49,7 @@
               <tr>
                 <td><a href='/2019'>2019</a></td>
                 <td><a href='/speakers/Masatoshi+SEKI'>Masatoshi SEKI</a></td>
-                <td><a href='https://rubykaigi.org/2019/presentations/m_seki.html#apr20' target='_blank'>dRuby 20th anniversary hands-on workshop(14:20 - 15:30)</a></td>
+                <td><a href='https://rubykaigi.org/2019/presentations/m_seki.html#apr20' target='_blank'>dRuby 20th anniversary hands-on workshop</a></td>
               </tr>
               
               <tr>
@@ -61,7 +61,7 @@
               <tr>
                 <td><a href='/2019'>2019</a></td>
                 <td><a href='/speakers/Sutou+Kouhei'>Sutou Kouhei</a></td>
-                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop(14:20 - 15:30)</a></td>
+                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop</a></td>
               </tr>
               
               <tr>
@@ -115,7 +115,7 @@
               <tr>
                 <td><a href='/2019'>2019</a></td>
                 <td><a href='/speakers/Kenta+Murata'>Kenta Murata</a></td>
-                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop(14:20 - 15:30)</a></td>
+                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop</a></td>
               </tr>
               
               <tr>
@@ -139,7 +139,7 @@
               <tr>
                 <td><a href='/2019'>2019</a></td>
                 <td><a href='/speakers/Kazuhiro+NISHIYAMA'>Kazuhiro NISHIYAMA</a></td>
-                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop(14:20 - 15:30)</a></td>
+                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop</a></td>
               </tr>
               
               <tr>
@@ -312,6 +312,12 @@
               
               <tr>
                 <td><a href='/2019'>2019</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2019/presentations/rubylangorg.html#apr20' target='_blank'>Ruby Committers vs the World</a></td>
+              </tr>
+              
+              <tr>
+                <td><a href='/2019'>2019</a></td>
                 <td><a href='/speakers/Matz+%26+the+Ruby+Core+Team'>Matz & the Ruby Core Team</a></td>
                 <td><a href='https://rubykaigi.org/2019/presentations/matzbot.html#apr18' target='_blank'>Ruby 3 Progress Report</a></td>
               </tr>
@@ -379,7 +385,7 @@
               <tr>
                 <td><a href='/2019'>2019</a></td>
                 <td><a href='/speakers/Kazuma+Furuhashi'>Kazuma Furuhashi</a></td>
-                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop(14:20 - 15:30)</a></td>
+                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop</a></td>
               </tr>
               
               <tr>
@@ -415,7 +421,7 @@
               <tr>
                 <td><a href='/2019'>2019</a></td>
                 <td><a href='/speakers/Kozo+Nishida'>Kozo Nishida</a></td>
-                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop(14:20 - 15:30)</a></td>
+                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop</a></td>
               </tr>
               
               <tr>

--- a/2019/index.html
+++ b/2019/index.html
@@ -258,6 +258,12 @@
               
               <tr>
                 <td><a href='/2019'>2019</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2019/presentations/rubylangorg.html#apr20' target='_blank'>Ruby Committers vs the World</a></td>
+              </tr>
+              
+              <tr>
+                <td><a href='/2019'>2019</a></td>
                 <td><a href='/speakers/ITOYANAGI+Sakura'>ITOYANAGI Sakura</a></td>
                 <td><a href='https://rubykaigi.org/2019/presentations/aycabta.html#apr18' target='_blank'>Terminal Editors For Ruby Core Toolchain</a></td>
               </tr>
@@ -308,12 +314,6 @@
                 <td><a href='/2019'>2019</a></td>
                 <td><a href='/speakers/Genadi+Samokovarov'>Genadi Samokovarov</a></td>
                 <td><a href='https://rubykaigi.org/2019/presentations/gsamokovarov.html#apr18' target='_blank'>Writing Debuggers in Plain Ruby! Fact or fiction?</a></td>
-              </tr>
-              
-              <tr>
-                <td><a href='/2019'>2019</a></td>
-                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
-                <td><a href='https://rubykaigi.org/2019/presentations/rubylangorg.html#apr20' target='_blank'>Ruby Committers vs the World</a></td>
               </tr>
               
               <tr>

--- a/2020-takeout/index.html
+++ b/2020-takeout/index.html
@@ -120,6 +120,18 @@
               
               <tr>
                 <td><a href='/2020-takeout'>2020-takeout</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2020-takeout/presentations/rubylangorg.html#sep04' target='_blank'>Ruby Committers vs the World</a></td>
+              </tr>
+              
+              <tr>
+                <td><a href='/2020-takeout'>2020-takeout</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2020-takeout/presentations/rubylangorg.html#sep05' target='_blank'>Ruby Committers vs the World</a></td>
+              </tr>
+              
+              <tr>
+                <td><a href='/2020-takeout'>2020-takeout</a></td>
                 <td><a href='/speakers/ITOYANAGI+Sakura'>ITOYANAGI Sakura</a></td>
                 <td><a href='https://rubykaigi.org/2020-takeout/presentations/aycabta.html#sep05' target='_blank'>The Complex Nightmare of the Asian Cultural Area</a></td>
               </tr>

--- a/2021-takeout/index.html
+++ b/2021-takeout/index.html
@@ -126,6 +126,12 @@
               
               <tr>
                 <td><a href='/2021-takeout'>2021-takeout</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2021-takeout/presentations/rubylangorg.html' target='_blank'>Ruby Committers vs the World</a></td>
+              </tr>
+              
+              <tr>
+                <td><a href='/2021-takeout'>2021-takeout</a></td>
                 <td><a href='/speakers/ITOYANAGI+Sakura'>ITOYANAGI Sakura</a></td>
                 <td><a href='https://rubykaigi.org/2021-takeout/presentations/aycabta.html' target='_blank'>Graphical Terminal User Interface of Ruby 3.1</a></td>
               </tr>
@@ -146,12 +152,6 @@
                 <td><a href='/2021-takeout'>2021-takeout</a></td>
                 <td><a href='/speakers/Hitoshi+HASUMI'>Hitoshi HASUMI</a></td>
                 <td><a href='https://rubykaigi.org/2021-takeout/presentations/hasumikin.html' target='_blank'>PRK Firmware: Keyboard is Essentially Ruby</a></td>
-              </tr>
-              
-              <tr>
-                <td><a href='/2021-takeout'>2021-takeout</a></td>
-                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
-                <td><a href='https://rubykaigi.org/2021-takeout/presentations/rubylangorg.html' target='_blank'>Ruby Committers vs the World</a></td>
               </tr>
               
               <tr>

--- a/2022/index.html
+++ b/2022/index.html
@@ -126,6 +126,12 @@
               
               <tr>
                 <td><a href='/2022'>2022</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2022/presentations/rubylangorg.html#day2' target='_blank'>Ruby Committers vs The World</a></td>
+              </tr>
+              
+              <tr>
+                <td><a href='/2022'>2022</a></td>
                 <td><a href='/speakers/Chris+Salzberg'>Chris Salzberg</a></td>
                 <td><a href='https://rubykaigi.org/2022/presentations/shioyama.html#day2' target='_blank'>Caching With MessagePack</a></td>
               </tr>
@@ -146,12 +152,6 @@
                 <td><a href='/2022'>2022</a></td>
                 <td><a href='/speakers/Koichi+ITO'>Koichi ITO</a></td>
                 <td><a href='https://rubykaigi.org/2022/presentations/koic.html#day2' target='_blank'>Make RuboCop super fast</a></td>
-              </tr>
-              
-              <tr>
-                <td><a href='/2022'>2022</a></td>
-                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
-                <td><a href='https://rubykaigi.org/2022/presentations/rubylangorg.html#day2' target='_blank'>Ruby Committers vs The World</a></td>
               </tr>
               
               <tr>

--- a/2023/index.html
+++ b/2023/index.html
@@ -120,6 +120,12 @@
               
               <tr>
                 <td><a href='/2023'>2023</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2023/presentations/rubylangorg.html#day3' target='_blank'>Ruby Committers and The World</a></td>
+              </tr>
+              
+              <tr>
+                <td><a href='/2023'>2023</a></td>
                 <td><a href='/speakers/Chris+Salzberg'>Chris Salzberg</a></td>
                 <td><a href='https://rubykaigi.org/2023/presentations/shioyama.html#day2' target='_blank'>Multiverse Ruby</a></td>
               </tr>
@@ -158,12 +164,6 @@
                 <td><a href='/2023'>2023</a></td>
                 <td><a href='/speakers/Genadi+Samokovarov'>Genadi Samokovarov</a></td>
                 <td><a href='https://rubykaigi.org/2023/presentations/gsamokovarov.html#day1' target='_blank'>RuboCop's baddest cop</a></td>
-              </tr>
-              
-              <tr>
-                <td><a href='/2023'>2023</a></td>
-                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
-                <td><a href='https://rubykaigi.org/2023/presentations/rubylangorg.html#day3' target='_blank'>Ruby Committers and The World</a></td>
               </tr>
               
               <tr>

--- a/2024/index.html
+++ b/2024/index.html
@@ -114,6 +114,12 @@
               
               <tr>
                 <td><a href='/2024'>2024</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2024/presentations/rubylangorg.html#day3' target='_blank'>Ruby Committers and the World</a></td>
+              </tr>
+              
+              <tr>
+                <td><a href='/2024'>2024</a></td>
                 <td><a href='/speakers/Masataka+Kuwabara'>Masataka Kuwabara</a></td>
                 <td><a href='https://rubykaigi.org/2024/presentations/p_ck_.html#day2' target='_blank'>Community-driven RBS repository</a></td>
               </tr>
@@ -140,12 +146,6 @@
                 <td><a href='/2024'>2024</a></td>
                 <td><a href='/speakers/Vladimir+Dementyev'>Vladimir Dementyev</a></td>
                 <td><a href='https://rubykaigi.org/2024/presentations/palkan_tula.html#day3' target='_blank'>Ruby Mixology 101: adding shots of PHP, Elixir, and more</a></td>
-              </tr>
-              
-              <tr>
-                <td><a href='/2024'>2024</a></td>
-                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
-                <td><a href='https://rubykaigi.org/2024/presentations/rubylangorg.html#day3' target='_blank'>Ruby Committers and the World</a></td>
               </tr>
               
               <tr>

--- a/downloader.rb
+++ b/downloader.rb
@@ -11,7 +11,7 @@ class Downloader
     '2023' => yamls_for(2023),
     '2022' => yamls_for(2022),
     '2021-takeout' => yamls_for('2021-takeout'),
-    '2020-takeout' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2020-takeout/schedule/index.html'],
+    '2020-takeout' => yamls_for('2020-takeout'),
     '2019' => yamls_for(2019),
     '2018' => yamls_for(2018),
     '2017' => yamls_for(2017),

--- a/downloader.rb
+++ b/downloader.rb
@@ -13,7 +13,7 @@ class Downloader
     '2021-takeout' => yamls_for('2021-takeout'),
     '2020-takeout' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2020-takeout/schedule/index.html'],
     '2019' => yamls_for(2019),
-    '2018' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2018/schedule/index.html'],
+    '2018' => yamls_for(2018),
     '2017' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2017/schedule/index.html'],
     '2016' => yamls_for(2016),
     '2015' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2015/schedule/index.html'],

--- a/downloader.rb
+++ b/downloader.rb
@@ -12,7 +12,7 @@ class Downloader
     '2022' => yamls_for(2022),
     '2021-takeout' => yamls_for('2021-takeout'),
     '2020-takeout' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2020-takeout/schedule/index.html'],
-    '2019' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2019/schedule/index.html'],
+    '2019' => yamls_for(2019),
     '2018' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2018/schedule/index.html'],
     '2017' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2017/schedule/index.html'],
     '2016' => yamls_for(2016),

--- a/downloader.rb
+++ b/downloader.rb
@@ -14,7 +14,7 @@ class Downloader
     '2020-takeout' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2020-takeout/schedule/index.html'],
     '2019' => yamls_for(2019),
     '2018' => yamls_for(2018),
-    '2017' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2017/schedule/index.html'],
+    '2017' => yamls_for(2017),
     '2016' => yamls_for(2016),
     '2015' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2015/schedule/index.html'],
     '2014' => ['https://raw.githubusercontent.com/ruby-no-kai/rubykaigi-static/master/2014/schedule/index.html'],

--- a/index.html
+++ b/index.html
@@ -481,7 +481,7 @@
               <tr>
                 <td><a href='/2019'>2019</a></td>
                 <td><a href='/speakers/Masatoshi+SEKI'>Masatoshi SEKI</a></td>
-                <td><a href='https://rubykaigi.org/2019/presentations/m_seki.html#apr20' target='_blank'>dRuby 20th anniversary hands-on workshop(14:20 - 15:30)</a></td>
+                <td><a href='https://rubykaigi.org/2019/presentations/m_seki.html#apr20' target='_blank'>dRuby 20th anniversary hands-on workshop</a></td>
               </tr>
               
               <tr>
@@ -679,7 +679,7 @@
               <tr>
                 <td><a href='/2019'>2019</a></td>
                 <td><a href='/speakers/Sutou+Kouhei'>Sutou Kouhei</a></td>
-                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop(14:20 - 15:30)</a></td>
+                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop</a></td>
               </tr>
               
               <tr>
@@ -1663,7 +1663,7 @@
               <tr>
                 <td><a href='/2019'>2019</a></td>
                 <td><a href='/speakers/Kenta+Murata'>Kenta Murata</a></td>
-                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop(14:20 - 15:30)</a></td>
+                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop</a></td>
               </tr>
               
               <tr>
@@ -1975,7 +1975,7 @@
               <tr>
                 <td><a href='/2019'>2019</a></td>
                 <td><a href='/speakers/Kazuhiro+NISHIYAMA'>Kazuhiro NISHIYAMA</a></td>
-                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop(14:20 - 15:30)</a></td>
+                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop</a></td>
               </tr>
               
               <tr>
@@ -4307,6 +4307,12 @@
               </tr>
               
               <tr>
+                <td><a href='/2019'>2019</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2019/presentations/rubylangorg.html#apr20' target='_blank'>Ruby Committers vs the World</a></td>
+              </tr>
+              
+              <tr>
                 <td><a href='/2021-takeout'>2021-takeout</a></td>
                 <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
                 <td><a href='https://rubykaigi.org/2021-takeout/presentations/rubylangorg.html' target='_blank'>Ruby Committers vs the World</a></td>
@@ -4495,7 +4501,7 @@
               <tr>
                 <td><a href='/2019'>2019</a></td>
                 <td><a href='/speakers/Kazuma+Furuhashi'>Kazuma Furuhashi</a></td>
-                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop(14:20 - 15:30)</a></td>
+                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop</a></td>
               </tr>
               
               <tr>
@@ -4531,7 +4537,7 @@
               <tr>
                 <td><a href='/2019'>2019</a></td>
                 <td><a href='/speakers/Kozo+Nishida'>Kozo Nishida</a></td>
-                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop(14:20 - 15:30)</a></td>
+                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop</a></td>
               </tr>
               
               <tr>

--- a/index.html
+++ b/index.html
@@ -3905,6 +3905,18 @@
               </tr>
               
               <tr>
+                <td><a href='/2020-takeout'>2020-takeout</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2020-takeout/presentations/rubylangorg.html#sep04' target='_blank'>Ruby Committers vs the World</a></td>
+              </tr>
+              
+              <tr>
+                <td><a href='/2020-takeout'>2020-takeout</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2020-takeout/presentations/rubylangorg.html#sep05' target='_blank'>Ruby Committers vs the World</a></td>
+              </tr>
+              
+              <tr>
                 <td><a href='/2021-takeout'>2021-takeout</a></td>
                 <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
                 <td><a href='https://rubykaigi.org/2021-takeout/presentations/rubylangorg.html' target='_blank'>Ruby Committers vs the World</a></td>

--- a/index.html
+++ b/index.html
@@ -3888,6 +3888,48 @@
               
               <tr>
                 <td><a href='/2017'>2017</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2017/presentations/rubylangorg.html' target='_blank'>Ruby Committers vs the World</a></td>
+              </tr>
+              
+              <tr>
+                <td><a href='/2018'>2018</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2018/presentations/rubylangorg.html#jun01' target='_blank'>Ruby Committers vs the World</a></td>
+              </tr>
+              
+              <tr>
+                <td><a href='/2019'>2019</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2019/presentations/rubylangorg.html#apr20' target='_blank'>Ruby Committers vs the World</a></td>
+              </tr>
+              
+              <tr>
+                <td><a href='/2021-takeout'>2021-takeout</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2021-takeout/presentations/rubylangorg.html' target='_blank'>Ruby Committers vs the World</a></td>
+              </tr>
+              
+              <tr>
+                <td><a href='/2022'>2022</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2022/presentations/rubylangorg.html#day2' target='_blank'>Ruby Committers vs The World</a></td>
+              </tr>
+              
+              <tr>
+                <td><a href='/2023'>2023</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2023/presentations/rubylangorg.html#day3' target='_blank'>Ruby Committers and The World</a></td>
+              </tr>
+              
+              <tr>
+                <td><a href='/2024'>2024</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2024/presentations/rubylangorg.html#day3' target='_blank'>Ruby Committers and the World</a></td>
+              </tr>
+              
+              <tr>
+                <td><a href='/2017'>2017</a></td>
                 <td><a href='/speakers/Chris+Salzberg'>Chris Salzberg</a></td>
                 <td><a href='https://rubykaigi.org/2017/presentations/shioyama.html' target='_blank'>The Ruby Module Builder Pattern</a></td>
               </tr>
@@ -4298,42 +4340,6 @@
                 <td><a href='/2024'>2024</a></td>
                 <td><a href='/speakers/Vladimir+Dementyev'>Vladimir Dementyev</a></td>
                 <td><a href='https://rubykaigi.org/2024/presentations/palkan_tula.html#day3' target='_blank'>Ruby Mixology 101: adding shots of PHP, Elixir, and more</a></td>
-              </tr>
-              
-              <tr>
-                <td><a href='/2018'>2018</a></td>
-                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
-                <td><a href='https://rubykaigi.org/2018/presentations/rubylangorg.html#jun01' target='_blank'>Ruby Committers vs the World</a></td>
-              </tr>
-              
-              <tr>
-                <td><a href='/2019'>2019</a></td>
-                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
-                <td><a href='https://rubykaigi.org/2019/presentations/rubylangorg.html#apr20' target='_blank'>Ruby Committers vs the World</a></td>
-              </tr>
-              
-              <tr>
-                <td><a href='/2021-takeout'>2021-takeout</a></td>
-                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
-                <td><a href='https://rubykaigi.org/2021-takeout/presentations/rubylangorg.html' target='_blank'>Ruby Committers vs the World</a></td>
-              </tr>
-              
-              <tr>
-                <td><a href='/2022'>2022</a></td>
-                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
-                <td><a href='https://rubykaigi.org/2022/presentations/rubylangorg.html#day2' target='_blank'>Ruby Committers vs The World</a></td>
-              </tr>
-              
-              <tr>
-                <td><a href='/2023'>2023</a></td>
-                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
-                <td><a href='https://rubykaigi.org/2023/presentations/rubylangorg.html#day3' target='_blank'>Ruby Committers and The World</a></td>
-              </tr>
-              
-              <tr>
-                <td><a href='/2024'>2024</a></td>
-                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
-                <td><a href='https://rubykaigi.org/2024/presentations/rubylangorg.html#day3' target='_blank'>Ruby Committers and the World</a></td>
               </tr>
               
               <tr>

--- a/lib/speaker.rb
+++ b/lib/speaker.rb
@@ -379,6 +379,8 @@ class Speaker
               "/#{year}/presentations/#{talk_id}.html##{[nil, 'may31', 'jun01', 'jun02'][day]}"
             elsif year == '2019'
               "/#{year}/presentations/#{talk_id}.html#apr#{day + 17}"
+            elsif year == '2020-takeout'
+              "/#{year}/presentations/#{talk_id}.html#sep0#{day + 3}"
             elsif year.to_i >= 2022
               "/#{year}/presentations/#{talk_id}.html#day#{day}"
             else

--- a/lib/speaker.rb
+++ b/lib/speaker.rb
@@ -374,7 +374,15 @@ class Speaker
       schedule_yml = YAML.load_file(File.expand_path("schedule/#{year}/schedule.yml"))
       schedule_yml.each_value.with_index(1) do |schedule_per_day, day|
         schedule_per_day['events'].filter_map { it['talks']&.values }.flatten.each do |talk_id|
-          url = "/#{year}/presentations/#{talk_id}.html#{"#day#{day}" if year.to_i >= 2022}"
+          url =
+            if year == '2019'
+              "/#{year}/presentations/#{talk_id}.html#apr#{day + 17}"
+            elsif year.to_i >= 2022
+              "/#{year}/presentations/#{talk_id}.html#day#{day}"
+            else
+              "/#{year}/presentations/#{talk_id}.html"
+            end
+
           speaker_id_to_speaker_ids[talk_id].each do |speaker_id|
             if (name = speaker_id_to_name[speaker_id])
               name = SpeakerNormalizer.unify(name)

--- a/lib/speaker.rb
+++ b/lib/speaker.rb
@@ -375,7 +375,9 @@ class Speaker
       schedule_yml.each_value.with_index(1) do |schedule_per_day, day|
         schedule_per_day['events'].filter_map { it['talks']&.values }.flatten.each do |talk_id|
           url =
-            if year == '2019'
+            if year == '2018'
+              "/#{year}/presentations/#{talk_id}.html##{[nil, 'may31', 'jun01', 'jun02'][day]}"
+            elsif year == '2019'
               "/#{year}/presentations/#{talk_id}.html#apr#{day + 17}"
             elsif year.to_i >= 2022
               "/#{year}/presentations/#{talk_id}.html#day#{day}"

--- a/speakers/CRuby+Committers/index.html
+++ b/speakers/CRuby+Committers/index.html
@@ -41,6 +41,18 @@
               </tr>
               
               <tr>
+                <td><a href='/2020-takeout'>2020-takeout</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2020-takeout/presentations/rubylangorg.html#sep04' target='_blank'>Ruby Committers vs the World</a></td>
+              </tr>
+              
+              <tr>
+                <td><a href='/2020-takeout'>2020-takeout</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2020-takeout/presentations/rubylangorg.html#sep05' target='_blank'>Ruby Committers vs the World</a></td>
+              </tr>
+              
+              <tr>
                 <td><a href='/2021-takeout'>2021-takeout</a></td>
                 <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
                 <td><a href='https://rubykaigi.org/2021-takeout/presentations/rubylangorg.html' target='_blank'>Ruby Committers vs the World</a></td>

--- a/speakers/CRuby+Committers/index.html
+++ b/speakers/CRuby+Committers/index.html
@@ -23,6 +23,12 @@
             <tbody>
               
               <tr>
+                <td><a href='/2017'>2017</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2017/presentations/rubylangorg.html' target='_blank'>Ruby Committers vs the World</a></td>
+              </tr>
+              
+              <tr>
                 <td><a href='/2018'>2018</a></td>
                 <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
                 <td><a href='https://rubykaigi.org/2018/presentations/rubylangorg.html#jun01' target='_blank'>Ruby Committers vs the World</a></td>

--- a/speakers/CRuby+Committers/index.html
+++ b/speakers/CRuby+Committers/index.html
@@ -29,6 +29,12 @@
               </tr>
               
               <tr>
+                <td><a href='/2019'>2019</a></td>
+                <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
+                <td><a href='https://rubykaigi.org/2019/presentations/rubylangorg.html#apr20' target='_blank'>Ruby Committers vs the World</a></td>
+              </tr>
+              
+              <tr>
                 <td><a href='/2021-takeout'>2021-takeout</a></td>
                 <td><a href='/speakers/CRuby+Committers'>CRuby Committers</a></td>
                 <td><a href='https://rubykaigi.org/2021-takeout/presentations/rubylangorg.html' target='_blank'>Ruby Committers vs the World</a></td>

--- a/speakers/Kazuhiro+NISHIYAMA/index.html
+++ b/speakers/Kazuhiro+NISHIYAMA/index.html
@@ -49,7 +49,7 @@
               <tr>
                 <td><a href='/2019'>2019</a></td>
                 <td><a href='/speakers/Kazuhiro+NISHIYAMA'>Kazuhiro NISHIYAMA</a></td>
-                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop(14:20 - 15:30)</a></td>
+                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop</a></td>
               </tr>
               
               <tr>

--- a/speakers/Kazuma+Furuhashi/index.html
+++ b/speakers/Kazuma+Furuhashi/index.html
@@ -31,7 +31,7 @@
               <tr>
                 <td><a href='/2019'>2019</a></td>
                 <td><a href='/speakers/Kazuma+Furuhashi'>Kazuma Furuhashi</a></td>
-                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop(14:20 - 15:30)</a></td>
+                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop</a></td>
               </tr>
               
             </tbody>

--- a/speakers/Kenta+Murata/index.html
+++ b/speakers/Kenta+Murata/index.html
@@ -61,7 +61,7 @@
               <tr>
                 <td><a href='/2019'>2019</a></td>
                 <td><a href='/speakers/Kenta+Murata'>Kenta Murata</a></td>
-                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop(14:20 - 15:30)</a></td>
+                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop</a></td>
               </tr>
               
               <tr>

--- a/speakers/Kozo+Nishida/index.html
+++ b/speakers/Kozo+Nishida/index.html
@@ -25,7 +25,7 @@
               <tr>
                 <td><a href='/2019'>2019</a></td>
                 <td><a href='/speakers/Kozo+Nishida'>Kozo Nishida</a></td>
-                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop(14:20 - 15:30)</a></td>
+                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop</a></td>
               </tr>
               
             </tbody>

--- a/speakers/Masatoshi+SEKI/index.html
+++ b/speakers/Masatoshi+SEKI/index.html
@@ -97,7 +97,7 @@
               <tr>
                 <td><a href='/2019'>2019</a></td>
                 <td><a href='/speakers/Masatoshi+SEKI'>Masatoshi SEKI</a></td>
-                <td><a href='https://rubykaigi.org/2019/presentations/m_seki.html#apr20' target='_blank'>dRuby 20th anniversary hands-on workshop(14:20 - 15:30)</a></td>
+                <td><a href='https://rubykaigi.org/2019/presentations/m_seki.html#apr20' target='_blank'>dRuby 20th anniversary hands-on workshop</a></td>
               </tr>
               
               <tr>

--- a/speakers/Sutou+Kouhei/index.html
+++ b/speakers/Sutou+Kouhei/index.html
@@ -103,7 +103,7 @@
               <tr>
                 <td><a href='/2019'>2019</a></td>
                 <td><a href='/speakers/Sutou+Kouhei'>Sutou Kouhei</a></td>
-                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop(14:20 - 15:30)</a></td>
+                <td><a href='https://rubykaigi.org/2019/presentations/mrkn_workshop.html#apr19' target='_blank'>RubyData Workshop</a></td>
               </tr>
               
               <tr>


### PR DESCRIPTION
#10 の続編です。 https://github.com/ruby-no-kai/rubykaigi-static/pull/63 にて、過去にさかのぼって2015以降の全てのKaigiのYAMLデータを公開したので、それを利用する形にこちらをアップデートしています。ただし、2015はなんかクセモノっぽくてちょっと差分が大きくなりそうなので、このパッチではいったん2016以降のものだけを対象にしています。

コミットの順番はなぜか 2019, 2018, 2017, 2020-takeout っていう順番になってますが、これは特に深い理由があったりするわけじゃなくて、単に作業した順です。

実際に回してみると、2018以外のそれぞれの年の生成結果にHTMLから持ってきたものとちょっとずつ差分が出ているので、差分を把握しやすいように、都度main.rb実行結果をコミットしています。ざっと見たところ、差分の内容は以下のような感じっぽいです。
2019
- vs the World追加
- 各ワークショップがYAML上では時刻の入っていないタイトルになっている

2018: 差分なし

2017
- vs the World追加

2020-takeout
- vs the World追加(2回)